### PR TITLE
Visual Studio Fix, RPATH handling improvement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,40 @@ IF(MSVC)
 
 ENDIF()
 
+##
+# Configuration for post-install RPath
+# Adapted from http://www.cmake.org/Wiki/CMake_RPATH_handling
+##
+IF(NOT MSVC)
+  # use, i.e. don't skip the full RPATH for the build tree
+  SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
+
+  # when building, don't use the install RPATH already
+  # (but later on when installing)
+  SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+
+  if(APPLE)
+    set(CMAKE_MACOSX_RPATH ON)
+  endif(APPLE)
+
+  # add the automatically determined parts of the RPATH
+  # which point to directories outside the build tree to the install RPATH
+  SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
+  # the RPATH to be used when installing,
+  # but only if it's not a system directory
+  LIST(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" isSystemDir)
+  IF("${isSystemDir}" STREQUAL "-1")
+    SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
+  ENDIF("${isSystemDir}" STREQUAL "-1")
+
+ENDIF()
+
+##
+# End configuration for post-install RPath
+##
+
+
 ###
 # Fix to make sure we don't try to include unistd.h
 # when using Visual Studio.
@@ -130,7 +164,7 @@ FUNCTION(texi_doc input)
             DEPENDS ${ARGN}
             COMMAND ${MAKEINFO} -o ${file}.info -I ${common_source_dir}
                 ${common_input}
-            COMMAND ${MAKEINFO} -o ${file}.html -I ${common_source_dir} 
+            COMMAND ${MAKEINFO} -o ${file}.html -I ${common_source_dir}
                 --html --no-split ${common_input}
             VERBATIM
             COMMENT "Creating documentation from ${common_input}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,15 @@ IF(MSVC)
 
 ENDIF()
 
+###
+# Fix to make sure we don't try to include unistd.h
+# when using Visual Studio.
+###
+INCLUDE(${CMAKE_ROOT}/Modules/CheckIncludeFile.cmake)
+CHECK_INCLUDE_FILE("unistd.h" HAVE_UNISTD_H)
+IF(NOT HAVE_UNISTD_H)
+  SET(YY_NO_UNISTD_H TRUE)
+ENDIF()
 
 # Ensures a path in the native format.
 #FUNCTION(to_native_path input result)

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -4,3 +4,5 @@
 #define DEFAULT_UDUNITS2_XML_PATH "@DEFAULT_UDUNITS2_XML_PATH@"
 #cmakedefine DLL_UDUNITS2
 #cmakedefine DLL_EXPORT
+#cmakedefine HAVE_UNISTD_H 
+#cmakedefine YY_NO_UNISTD_H 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -4,18 +4,29 @@ IF (CUNIT_INCLUDE_DIR)
     INCLUDE_DIRECTORIES("${CUNIT_INCLUDE_DIR}")
 ENDIF()
 
+##
+# Check to see if we have flex and bison.
+##
+FIND_PROGRAM(UD_FLEX NAMES flex)
+FIND_PROGRAM(UD_BISON NAMES bison)
+
 # Ensure that the C source-files for the scanner and parser are up-to-date
 # on a Unix system.
-if (UNIX)
+#
+# MODIFICATION: Instead of checking for Unix, see if flex and bison
+# are available.
+#
+
+IF(UD_FLEX AND UD_BISON)
     add_custom_command(
         OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/scanner.c
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        COMMAND flex -d -Put -o scanner.c scanner.l
+        COMMAND ${UD_FLEX} -d -Put -o scanner.c scanner.l
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/scanner.l)
     add_custom_command(
         OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/parser.c
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        COMMAND bison -t -p ut -o parser.c parser.y
+        COMMAND ${UD_BISON} -t -p ut -o parser.c parser.y
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/parser.y)
     set_source_files_properties(parser.c
         PROPERTIES OBJECT_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/scanner.c)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -4,6 +4,10 @@ IF (CUNIT_INCLUDE_DIR)
     INCLUDE_DIRECTORIES("${CUNIT_INCLUDE_DIR}")
 ENDIF()
 
+IF(YY_NO_UNISTD_H)
+    ADD_DEFINITIONS(-DYY_NO_UNISTD_H)
+ENDIF(YY_NO_UNISTD_H)
+
 ##
 # Check to see if we have flex and bison.
 ##
@@ -16,8 +20,11 @@ FIND_PROGRAM(UD_BISON NAMES bison)
 # MODIFICATION: Instead of checking for Unix, see if flex and bison
 # are available.
 #
+# MODIFICATION 2: Moving back for now, but leaving framework.
+#  Other complications arose on Windows with MSVC.
+#
 
-IF(UD_FLEX AND UD_BISON)
+IF(UNIX)
     add_custom_command(
         OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/scanner.c
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}

--- a/lib/scanner.c
+++ b/lib/scanner.c
@@ -1,5 +1,6 @@
+#line 2 "scanner.c"
 
-#line 3 "<stdout>"
+#line 4 "scanner.c"
 
 #define  YY_INT_ALIGNED short int
 
@@ -35,7 +36,7 @@
 #define FLEX_SCANNER
 #define YY_FLEX_MAJOR_VERSION 2
 #define YY_FLEX_MINOR_VERSION 5
-#define YY_FLEX_SUBMINOR_VERSION 37
+#define YY_FLEX_SUBMINOR_VERSION 35
 #if YY_FLEX_SUBMINOR_VERSION > 0
 #define FLEX_BETA
 #endif
@@ -202,7 +203,15 @@ typedef unsigned int flex_uint32_t;
 
 /* Size of default input buffer. */
 #ifndef YY_BUF_SIZE
+#ifdef __ia64__
+/* On IA-64, the buffer size is 16k, not 8k.
+ * Moreover, YY_BUF_SIZE is 2*YY_READ_BUF_SIZE in the general case.
+ * Ditto for the __ia64__ case accordingly.
+ */
+#define YY_BUF_SIZE 32768
+#else
 #define YY_BUF_SIZE 16384
+#endif /* __ia64__ */
 #endif
 
 /* The state buf must be large enough to hold one state per character in the main buffer.
@@ -214,13 +223,8 @@ typedef unsigned int flex_uint32_t;
 typedef struct yy_buffer_state *YY_BUFFER_STATE;
 #endif
 
-#ifndef YY_TYPEDEF_YY_SIZE_T
-#define YY_TYPEDEF_YY_SIZE_T
-typedef size_t yy_size_t;
-#endif
-
 /* %if-not-reentrant */
-extern yy_size_t utleng;
+extern int utleng;
 /* %endif */
 
 /* %if-c-only */
@@ -251,6 +255,11 @@ extern FILE *utin, *utout;
 
 #define unput(c) yyunput( c, (yytext_ptr)  )
 
+#ifndef YY_TYPEDEF_YY_SIZE_T
+#define YY_TYPEDEF_YY_SIZE_T
+typedef size_t yy_size_t;
+#endif
+
 #ifndef YY_STRUCT_YY_BUFFER_STATE
 #define YY_STRUCT_YY_BUFFER_STATE
 struct yy_buffer_state
@@ -273,7 +282,7 @@ struct yy_buffer_state
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
 	 */
-	yy_size_t yy_n_chars;
+	int yy_n_chars;
 
 	/* Whether we "own" the buffer - i.e., we know we created it,
 	 * and can realloc() it to grow it, and should free() it to
@@ -357,8 +366,8 @@ static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
 
 /* yy_hold_char holds the character lost when uttext is formed. */
 static char yy_hold_char;
-static yy_size_t yy_n_chars;		/* number of characters read into yy_ch_buf */
-yy_size_t utleng;
+static int yy_n_chars;		/* number of characters read into yy_ch_buf */
+int utleng;
 
 /* Points to current character in buffer. */
 static char *yy_c_buf_p = (char *) 0;
@@ -389,7 +398,7 @@ static void ut_init_buffer (YY_BUFFER_STATE b,FILE *file  );
 
 YY_BUFFER_STATE ut_scan_buffer (char *base,yy_size_t size  );
 YY_BUFFER_STATE ut_scan_string (yyconst char *yy_str  );
-YY_BUFFER_STATE ut_scan_bytes (yyconst char *bytes,yy_size_t len  );
+YY_BUFFER_STATE ut_scan_bytes (yyconst char *bytes,int len  );
 
 /* %endif */
 
@@ -424,7 +433,7 @@ void utfree (void *  );
 /* %% [1.0] uttext/utin/utout/yy_state_type/utlineno etc. def's & init go here */
 /* Begin user sect3 */
 
-#define utwrap() 1
+#define utwrap(n) 1
 #define YY_SKIP_YYWRAP
 
 #define FLEX_DEBUG
@@ -1030,7 +1039,7 @@ static int decodeReal(
 }
 
 
-#line 1034 "<stdout>"
+#line 1043 "scanner.c"
 
 #define INITIAL 0
 #define ID_SEEN 1
@@ -1086,7 +1095,7 @@ FILE *utget_out (void );
 
 void utset_out  (FILE * out_str  );
 
-yy_size_t utget_leng (void );
+int utget_leng (void );
 
 char *utget_text (void );
 
@@ -1145,7 +1154,12 @@ static int input (void );
 
 /* Amount of stuff to slurp up with each read. */
 #ifndef YY_READ_BUF_SIZE
+#ifdef __ia64__
+/* On IA-64, the buffer size is 16k, not 8k */
+#define YY_READ_BUF_SIZE 16384
+#else
 #define YY_READ_BUF_SIZE 8192
+#endif /* __ia64__ */
 #endif
 
 /* Copy whatever the last rule matched to the standard output. */
@@ -1283,7 +1297,7 @@ YY_DECL
 	_restartScanner = 0;
     }
 
-#line 1287 "<stdout>"
+#line 1301 "scanner.c"
 
 	if ( !(yy_init) )
 		{
@@ -1650,7 +1664,7 @@ YY_RULE_SETUP
 #line 342 "scanner.l"
 ECHO;
 	YY_BREAK
-#line 1654 "<stdout>"
+#line 1668 "scanner.c"
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(ID_SEEN):
 case YY_STATE_EOF(SHIFT_SEEN):
@@ -1853,21 +1867,21 @@ static int yy_get_next_buffer (void)
 
 	else
 		{
-			yy_size_t num_to_read =
+			int num_to_read =
 			YY_CURRENT_BUFFER_LVALUE->yy_buf_size - number_to_move - 1;
 
 		while ( num_to_read <= 0 )
 			{ /* Not enough room in the buffer - grow it. */
 
 			/* just a shorter name for the current buffer */
-			YY_BUFFER_STATE b = YY_CURRENT_BUFFER_LVALUE;
+			YY_BUFFER_STATE b = YY_CURRENT_BUFFER;
 
 			int yy_c_buf_p_offset =
 				(int) ((yy_c_buf_p) - b->yy_ch_buf);
 
 			if ( b->yy_is_our_buffer )
 				{
-				yy_size_t new_size = b->yy_buf_size * 2;
+				int new_size = b->yy_buf_size * 2;
 
 				if ( new_size <= 0 )
 					b->yy_buf_size += b->yy_buf_size / 8;
@@ -1898,7 +1912,7 @@ static int yy_get_next_buffer (void)
 
 		/* Read in more data. */
 		YY_INPUT( (&YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[number_to_move]),
-			(yy_n_chars), num_to_read );
+			(yy_n_chars), (size_t) num_to_read );
 
 		YY_CURRENT_BUFFER_LVALUE->yy_n_chars = (yy_n_chars);
 		}
@@ -2006,7 +2020,7 @@ static int yy_get_next_buffer (void)
 	yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
 	yy_is_jam = (yy_current_state == 270);
 
-		return yy_is_jam ? 0 : yy_current_state;
+	return yy_is_jam ? 0 : yy_current_state;
 }
 
 /* %if-c-only */
@@ -2026,7 +2040,7 @@ static int yy_get_next_buffer (void)
 	if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
 		{ /* need to shift things up to make room */
 		/* +2 for EOB chars. */
-		register yy_size_t number_to_move = (yy_n_chars) + 2;
+		register int number_to_move = (yy_n_chars) + 2;
 		register char *dest = &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[
 					YY_CURRENT_BUFFER_LVALUE->yy_buf_size + 2];
 		register char *source =
@@ -2084,7 +2098,7 @@ static int yy_get_next_buffer (void)
 
 		else
 			{ /* need more input */
-			yy_size_t offset = (yy_c_buf_p) - (yytext_ptr);
+			int offset = (yy_c_buf_p) - (yytext_ptr);
 			++(yy_c_buf_p);
 
 			switch ( yy_get_next_buffer(  ) )
@@ -2268,6 +2282,17 @@ static void ut_load_buffer_state  (void)
 	utfree((void *) b  );
 }
 
+/* %if-c-only */
+
+#ifndef __cplusplus
+extern int isatty (int );
+#endif /* __cplusplus */
+    
+/* %endif */
+
+/* %if-c++-only */
+/* %endif */
+
 /* Initializes or reinitializes a buffer.
  * This function is sometimes called more than once on the same buffer,
  * such as during a utrestart() or at EOF.
@@ -2410,7 +2435,7 @@ static void utensure_buffer_stack (void)
 /* %if-c++-only */
 /* %endif */
 {
-	yy_size_t num_to_alloc;
+	int num_to_alloc;
     
 	if (!(yy_buffer_stack)) {
 
@@ -2513,12 +2538,12 @@ YY_BUFFER_STATE ut_scan_string (yyconst char * yystr )
  * 
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE ut_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len )
+YY_BUFFER_STATE ut_scan_bytes  (yyconst char * yybytes, int  _yybytes_len )
 {
 	YY_BUFFER_STATE b;
 	char *buf;
 	yy_size_t n;
-	yy_size_t i;
+	int i;
     
 	/* Get memory for full buffer, including space for trailing EOB's. */
 	n = _yybytes_len + 2;
@@ -2609,7 +2634,7 @@ FILE *utget_out  (void)
 /** Get the length of the current token.
  * 
  */
-yy_size_t utget_leng  (void)
+int utget_leng  (void)
 {
         return utleng;
 }


### PR DESCRIPTION
Corrected an issue I reported in UDUNITS-2 https://github.com/Unidata/UDUNITS-2/issues/40, e.g. Visual-Studio based Windows builds were broken due to a dependency on unistd.h introduced by flex.  This issue was corrected in CMake-based builds, as these are the only type of builds on Windows that use Visual Studio.

I also added some cmake configuration for handling RPATH values post-install. This squelches an OSX-specific cmake warning that was being reported, and addresses some linux corner cases.