### PR TITLE
Add AppVeyor CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,60 @@
+environment:
+
+  # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
+  # /E:ON and /V:ON options are not enabled in the batch script interpreter
+  # See: http://stackoverflow.com/a/13751649/163740
+  CMD_IN_ENV: "cmd /E:ON /V:ON /C obvci_appveyor_python_build_env.cmd"
+
+  # The CONDA_PY is just to ensure we will test with vc 9, vc 10, and vc 14.
+  matrix:
+    - TARGET_ARCH: x64
+      CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
+
+    - TARGET_ARCH: x64
+      CONDA_PY: 34
+      CONDA_INSTALL_LOCN: C:\\Miniconda3-x64
+
+    - TARGET_ARCH: x64
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
+
+# We always use a 64-bit machine, but can build x86 distributions
+# with the TARGET_ARCH variable.
+platform:
+    - x64
+
+install:
+    # If there is a newer build queued for the same PR, cancel this one.
+    # The AppVeyor 'rollout builds' option is supposed to serve the same
+    # purpose but it is problematic because it tends to cancel builds pushed
+    # directly to master instead of just PR builds (or the converse).
+    # credits: JuliaLang developers.
+    - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+         https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
+         Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+           throw "There are newer queued builds for this pull request, failing early." }
+
+    # Add path, activate `conda` and update conda.
+    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
+    - cmd: conda update --yes --quiet conda
+    - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
+
+    - cmd: set PYTHONUNBUFFERED=1
+
+    # Ensure defaults and conda-forge channels are present.
+    - cmd: conda config --set show_channel_urls true
+    - cmd: conda config --remove channels defaults
+    - cmd: conda config --add channels defaults
+    - cmd: conda config --add channels conda-forge
+
+    # Conda build tools.
+    - cmd: conda install -n root --quiet --yes obvious-ci
+    - cmd: obvci_install_conda_build_tools.py
+    - cmd: conda info
+
+# Skip .NET project specific build phase.
+build: off
+
+test_script:
+    - "%CMD_IN_ENV% conda build conda.recipe --quiet"

--- a/conda.recipe/bld.bat
+++ b/conda.recipe/bld.bat
@@ -1,0 +1,26 @@
+:: Needed so we can find expat.h from expat.
+set LIB=%LIBRARY_LIB%;.\lib;%LIB%
+set LIBPATH=%LIBRARY_LIB%;.\lib;%LIBPATH%
+set INCLUDE=%LIBRARY_INC%;%INCLUDE%
+
+:: Install the udunits2 xml files.
+mkdir %LIBRARY_PREFIX%\share
+mkdir %LIBRARY_PREFIX%\share\udunits
+copy .\lib\*.xml %LIBRARY_PREFIX%\share\udunits\ || exit 1
+
+copy %RECIPE_DIR%\unistd.h %SRC_DIR% || exit 1
+
+cmake -G "NMake Makefiles" ^
+      -D EXPAT_INCLUDE_DIR=%LIBRARY_INC%\expat.h ^
+      -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+      -D CMAKE_BUILD_TYPE=Release ^
+      %SRC_DIR%
+if errorlevel 1 exit 1
+
+nmake libudunits2 || exit 1
+nmake udunits2 || exit 1
+
+copy prog\udunits2.exe %SCRIPTS%\udunits2.exe || exit 1
+copy lib\udunits2.dll %SCRIPTS%\udunits2.dll || exit 1
+copy lib\*.exp %LIBRARY_LIB%\ || exit 1
+copy lib\*.lib %LIBRARY_LIB%\ || exit 1

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,0 +1,34 @@
+{% set version = "dev" %}
+
+package:
+  name: udunits2
+  version: {{ version }}
+
+source:
+  path: ../
+
+build:
+  detect_binary_files_with_prefix: true
+  features:
+    - vc9  # [win and py27]
+    - vc10  # [win and py34]
+    - vc14  # [win and py>=35]
+
+requirements:
+  build:
+    - python  # [win]
+    - cmake  # [win]
+    - expat
+    - vc 9  # [win and py27]
+    - vc 10  # [win and py34]
+    - vc 14  # [win and py>=35]
+  run:
+    - expat
+    - vc 9  # [win and py27]
+    - vc 10  # [win and py34]
+    - vc 14  # [win and py>=35]
+
+test:
+  commands:
+    - udunits2 -h
+    - udunits2 -H meter -W miles


### PR DESCRIPTION
This PR adds Continuous integration tests for Windows. Right now it only test the build itself and if the commands `udunits2 -h` and `udunits2 -H meter -W miles` works. We can add more tests later.

In the PR we use `conda` to acquire the dependency: `expat`, and the build tools: `cmake` and the various Visual Studio versions: `vc` 9, 10, and 14.

The devs need to activate AppVeyor for this repository to activate the tests. Here are the logs from my account: https://ci.appveyor.com/project/ocefpaf/udunits-2

PS: this PR is similar to https://github.com/Unidata/netcdf-c/pull/347.