### PR TITLE
Fix Windows builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,4 @@
 environment:
-
-  # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
-  # /E:ON and /V:ON options are not enabled in the batch script interpreter
-  # See: http://stackoverflow.com/a/13751649/163740
-  CMD_IN_ENV: "cmd /E:ON /V:ON /C obvci_appveyor_python_build_env.cmd"
-
-  # The CONDA_PY is just to ensure we will test with vc 9, vc 10, and vc 14.
   matrix:
     - TARGET_ARCH: x64
       CONDA_PY: 27
@@ -19,8 +12,6 @@ environment:
       CONDA_PY: 36
       CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
 
-# We always use a 64-bit machine, but can build x86 distributions
-# with the TARGET_ARCH variable.
 platform:
     - x64
 
@@ -42,19 +33,14 @@ install:
 
     - cmd: set PYTHONUNBUFFERED=1
 
-    # Ensure defaults and conda-forge channels are present.
     - cmd: conda config --set show_channel_urls true
-    - cmd: conda config --remove channels defaults
-    - cmd: conda config --add channels defaults
     - cmd: conda config --add channels conda-forge
+    - cmd: conda install --yes conda-build
 
-    # Conda build tools.
-    - cmd: conda install -n root --quiet --yes obvious-ci
-    - cmd: obvci_install_conda_build_tools.py
     - cmd: conda info
 
 # Skip .NET project specific build phase.
 build: off
 
 test_script:
-    - "%CMD_IN_ENV% conda build conda.recipe --quiet"
+    - "conda build conda.recipe"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,12 +5,8 @@ environment:
       CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
     - TARGET_ARCH: x64
-      CONDA_PY: 34
-      CONDA_INSTALL_LOCN: C:\\Miniconda3-x64
-
-    - TARGET_ARCH: x64
       CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
+      CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
 
 platform:
     - x64
@@ -26,10 +22,13 @@ install:
          Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
            throw "There are newer queued builds for this pull request, failing early." }
 
+    # cygwin may break conda-build
+    - cmd: rmdir C:\cygwin /s /q
+
     # Add path, activate `conda` and update conda.
-    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
-    - cmd: conda update --yes --quiet conda
+    # Add path, activate `conda` and update conda.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
+    - cmd: conda update --yes --quiet conda
 
     - cmd: set PYTHONUNBUFFERED=1
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,7 @@ install:
 
     - cmd: conda config --set show_channel_urls true
     - cmd: conda config --add channels conda-forge
-    - cmd: conda install --yes conda-build
+    - cmd: conda install --yes conda-build=2.1.1
 
     - cmd: conda info
 

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,8 +1,6 @@
-{% set version = "dev" %}
-
 package:
   name: udunits2
-  version: {{ version }}
+  version: version: {{ GIT_DESCRIBE_TAG|replace("v","") }}
 
 source:
   path: ../

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -15,6 +15,7 @@ build:
 requirements:
   build:
     - python  # [win]
+    - cmake  # [win]
     - expat
     - vc 9  # [win and py27]
     - vc 10  # [win and py34]

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -15,7 +15,6 @@ build:
 requirements:
   build:
     - python  # [win]
-    - cmake  # [win]
     - expat
     - vc 9  # [win and py27]
     - vc 10  # [win and py34]

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: udunits2
-  version: version: {{ GIT_DESCRIBE_TAG|replace("v","") }}
+  version: {{ GIT_DESCRIBE_TAG|replace("v","") }}
 
 source:
   path: ../


### PR DESCRIPTION
The AppVeyor failure is related to a `conda-build` change where the manually copied `xml` are not available in the test phase. I am downgrading `conda-build` to `2.1.1` is for now. I'll unpin once the issue is resolved upstream.

However, that revealed a failure when building for `vc9` that I believe is legit. Probably due to a change in the cmake configure files:

```shell
(C:\Miniconda-x64\conda-bld\conda.recipe_1495810967610\_b_env) C:\Miniconda-x64\conda-bld\conda.recipe_1495810967610\work>cmake -G "NMake Makefiles"       -D EXPAT_INCLUDE_DIR=C:\Miniconda-x64\conda-bld\conda.recipe_1495810967610\_b_env\Library\include\expat.h       -D CMAKE_INSTALL_PREFIX=C:\Miniconda-x64\conda-bld\conda.recipe_1495810967610\_b_env\Library       -D CMAKE_BUILD_TYPE=Release       C:\Miniconda-x64\conda-bld\conda.recipe_1495810967610\work 
-- The C compiler identification is unknown
CMake Error at CMakeLists.txt:1 (PROJECT):
  The CMAKE_C_COMPILER:
    cl
  is not a full path and was not found in the PATH.
  To use the NMake generator with Visual C++, cmake must be run from a shell
  that can use the compiler cl from the command line.  This environment is
  unable to invoke the cl compiler.  To fix this problem, run cmake from the
  Visual Studio Command Prompt (vcvarsall.bat).
  Tell CMake where to find the compiler by setting either the environment
  variable "CC" or the CMake cache entry CMAKE_C_COMPILER to the full path to
  the compiler, or to the compiler name if it is in the PATH.
-- Configuring incomplete, errors occurred!
See also "C:/Miniconda-x64/conda-bld/conda.recipe_1495810967610/work/CMakeFiles/CMakeOutput.log".
See also "C:/Miniconda-x64/conda-bld/conda.recipe_1495810967610/work/CMakeFiles/CMakeError.log"
```