### PR TITLE
Use the shared library to locate the default xml

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -99,6 +99,8 @@ AC_SEARCH_LIBS([log10], [m], ,
 AC_SEARCH_LIBS([XML_StopParser], [expat], , 
     AC_MSG_ERROR([cannot find EXPAT function XML_StopParser]))
 
+AC_CHECK_LIB([dl], [dlopen])
+
 # Checks for header files.
 AC_HEADER_STDC
 AC_CHECK_HEADERS([float.h inttypes.h stddef.h stdlib.h string.h strings.h])

--- a/prog/udunits2.c
+++ b/prog/udunits2.c
@@ -61,10 +61,14 @@ static int		_wantDefinition; /* "have" unit definition desired? */
 static int		_formattingOptions = UT_DEFINITION;
 static int		_exitStatus = EXIT_FAILURE;
 
+extern const char*
+default_udunits2_xml_path();
 
 static void
 usage(void)
 {
+    const char * default_xml = default_udunits2_xml_path();
+
     (void)fprintf(stderr,
 "Usage:\n"
 "    %s -h\n"
@@ -80,7 +84,8 @@ usage(void)
 "    -W want    Use \"want\" unit for conversion. Empty string requests\n"
 "               definition of \"have\" unit. Default is reply to prompt.\n"
 "    XML_file   XML database file. Default is \"%s\".\n",
-        _progname, _progname, DEFAULT_UDUNITS2_XML_PATH);
+        _progname, _progname, default_xml);
+    free(default_xml);
 }
 
 /**


### PR DESCRIPTION
Reference: https://github.com/conda-forge/udunits2-feedstock/issues/18

Here, the Anaconda Distribution and conda-forge build their software to be relocatable (so that, for example it can be installed in the user's home directory). This conflicts with baking any paths in at compilation time so here I use features of the underlying OSes to allow relative re-location to take place.