### PR TITLE
fix appveyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,3 +38,4 @@ build: off
 
 test_script:
     - conda build conda.recipe
+    - if %ERRORLEVEL% NEQ 0 exit 1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,27 +1,8 @@
 environment:
   matrix:
     - TARGET_ARCH: x64
-      CONDA_PY: 27
-      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
-
-    # Python 36 fails:
-        #conda build conda.recipe
-        #Traceback (most recent call last):
-          #File "C:\Miniconda36-x64\Scripts\conda-build-script.py", line 3, in <module>
-            #import conda_build.cli.main_build
-          #File "C:\Miniconda36-x64\lib\site-packages\conda_build\cli\main_build.py", line 16, in <module>
-            #import conda_build.api as api
-          #File "C:\Miniconda36-x64\lib\site-packages\conda_build\api.py", line 22, in <module>
-            #from conda_build.config import Config, get_or_merge_config, DEFAULT_PREFIX_LENGTH as _prefix_length
-          #File "C:\Miniconda36-x64\lib\site-packages\conda_build\config.py", line 14, in <module>
-            #from .conda_interface import root_dir, root_writable, cc, subdir, platform
-          #File "C:\Miniconda36-x64\lib\site-packages\conda_build\conda_interface.py", line 22, in <module>
-            #from conda.resolve import MatchSpec, NoPackagesFound, Resolve, Unsatisfiable, normalized_version  # NOQA
-        #ImportError: cannot import name 'NoPackagesFound'
-        #Command exited with code 1
-    #- TARGET_ARCH: x64
-      #CONDA_PY: 36
-      #CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
 
 platform:
     - x64
@@ -37,26 +18,23 @@ install:
          Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
            throw "There are newer queued builds for this pull request, failing early." }
 
-    # cygwin may break conda-build
-    - cmd: rmdir C:\cygwin /s /q
-
     # Add path, activate `conda` and update conda.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
-    - cmd: conda update --yes --quiet conda
+    - cmd: conda config --set always_yes yes --set changeps1 no --set show_channel_urls true --set auto_update_conda false
+    - cmd: conda update conda
+    # We need to pin conda until https://github.com/conda/conda/issues/6556 is fixed.
+    - cmd: conda config --system --add pinned_packages defaults::conda
+    - cmd: conda config --add channels conda-forge --force
+
+    # Install conda-build.
+    - cmd: conda install conda-build
 
     - cmd: set PYTHONUNBUFFERED=1
-
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda config --add channels conda-forge
-    - cmd: conda install --yes conda-build=2.1.1
-
-    - cmd: conda info
-
-    - cmd: call "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64
-    - cmd: call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86_amd64
+    
+    - cmd: conda info --all
 
 # Skip .NET project specific build phase.
 build: off
 
 test_script:
-    - "conda build conda.recipe"
+    - conda build conda.recipe

--- a/conda.recipe/bld.bat
+++ b/conda.recipe/bld.bat
@@ -10,6 +10,8 @@ copy .\lib\*.xml %LIBRARY_PREFIX%\share\udunits\ || exit 1
 
 copy %RECIPE_DIR%\unistd.h %SRC_DIR% || exit 1
 
+mkdir build
+cd build
 cmake -G "NMake Makefiles" ^
       -D EXPAT_INCLUDE_DIR=%LIBRARY_INC%\expat.h ^
       -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
@@ -20,7 +22,9 @@ if errorlevel 1 exit 1
 nmake libudunits2 || exit 1
 nmake udunits2 || exit 1
 
+
 copy prog\udunits2.exe %SCRIPTS%\udunits2.exe || exit 1
 copy lib\udunits2.dll %SCRIPTS%\udunits2.dll || exit 1
+copy ..\lib\*.h %LIBRARY_INC%\ || exit 1
 copy lib\*.exp %LIBRARY_LIB%\ || exit 1
 copy lib\*.lib %LIBRARY_LIB%\ || exit 1

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -8,23 +8,17 @@ source:
 build:
   detect_binary_files_with_prefix: true
   features:
-    - vc9  # [win and py27]
-    - vc10  # [win and py34]
-    - vc14  # [win and py>=35]
+    - vc14  # [win and py>=36]
 
 requirements:
   build:
     - python  # [win]
     - cmake  # [win]
     - expat
-    - vc 9  # [win and py27]
-    - vc 10  # [win and py34]
-    - vc 14  # [win and py>=35]
+    - vc 14  # [win and py>=36]
   run:
     - expat
-    - vc 9  # [win and py27]
-    - vc 10  # [win and py34]
-    - vc 14  # [win and py>=35]
+    - vc 14  # [win and py>=36]
 
 test:
   commands:


### PR DESCRIPTION
This PR revives AppVeyor but, contrary to the green status, the build is failing with:

```
[ 94%] Building C object prog/CMakeFiles/udunits2.dir/XGetopt.c.obj
XGetopt.c
[100%] Linking C executable udunits2.exe
LINK: command "C:\PROGRA~2\MI0E91~1.0\VC\bin\amd64\link.exe /nologo @CMakeFiles\udunits2.dir\objects1.rsp /out:udunits2.exe /implib:udunits2.lib /pdb:C:\Miniconda36-x64\conda-bld\udunits2_1528730419962\work\build\prog\udunits2.pdb /version:0.0 /machine:x64 /INCREMENTAL:NO /subsystem:console -LIBPATH:C:\Miniconda36-x64\conda-bld\udunits2_1528730419962\work\build\lib ..\lib\udunits2.lib C:\Miniconda36-x64\conda-bld\udunits2_1528730419962\_h_env\Library\lib\expat.lib kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib /MANIFEST /MANIFESTFILE:udunits2.exe.manifest" failed (exit code 1120) with the following output:
udunits2.c.obj : error LNK2019: unresolved external symbol default_udunits2_xml_path referenced in function decodeCommandLine
udunits2.exe : fatal error LNK1120: 1 unresolved externals
NMAKE : fatal error U1077: 'C:\Miniconda36-x64\conda-bld\udunits2_1528730419962\_h_env\Library\bin\cmake.exe' : return code '0xffffffff'
Stop.
NMAKE : fatal error U1077: '"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\BIN\amd64\nmake.exe"' : return code '0x2'
Stop.
NMAKE : fatal error U1077: '"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\BIN\amd64\nmake.exe"' : return code '0x2'
Stop.
NMAKE : fatal error U1077: '"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\BIN\amd64\nmake.exe"' : return code '0x2'
Stop.
Traceback (most recent call last):
  File "C:\Miniconda36-x64\Scripts\conda-build-script.py", line 10, in <module>
    sys.exit(main())
  File "C:\Miniconda36-x64\lib\site-packages\conda_build\cli\main_build.py", line 420, in main
    execute(sys.argv[1:])
  File "C:\Miniconda36-x64\lib\site-packages\conda_build\cli\main_build.py", line 411, in execute
    verify=args.verify)
  File "C:\Miniconda36-x64\lib\site-packages\conda_build\api.py", line 200, in build
    notest=notest, need_source_download=need_source_download, variants=variants)
  File "C:\Miniconda36-x64\lib\site-packages\conda_build\build.py", line 2177, in build_tree
    notest=notest,
  File "C:\Miniconda36-x64\lib\site-packages\conda_build\build.py", line 1385, in build
    windows.build(m, build_file, stats=build_stats)
  File "C:\Miniconda36-x64\lib\site-packages\conda_build\windows.py", line 297, in build
    check_call_env(cmd, cwd=src_dir, stats=stats)
  File "C:\Miniconda36-x64\lib\site-packages\conda_build\utils.py", line 310, in check_call_env
    return _func_defaulting_env_to_os_environ('call', *popenargs, **kwargs)
  File "C:\Miniconda36-x64\lib\site-packages\conda_build\utils.py", line 290, in _func_defaulting_env_to_os_environ
    raise subprocess.CalledProcessError(proc.returncode, _args)
subprocess.CalledProcessError: Command '['cmd.exe', '/c', 'bld.bat']' returned non-zero exit status 1.
```

I have no idea why AppVeyor is reporting a green status when the last message is `subprocess.CalledProcessError: Command '['cmd.exe', '/c', 'bld.bat']' returned non-zero exit status 1.` @msarahan is this a bug in conda-build? Or am I using it wrong? This used to failed as expected some time ago :-/ 