### PR TITLE
Fix definition of Bm

### DIFF
--- a/lib/udunits2-common.xml
+++ b/lib/udunits2-common.xml
@@ -1589,7 +1589,7 @@ elements appear only within <aliases>.
         <unit>
             <def>lg(re 1 mW)</def>
             <aliases> <symbol>Bm</symbol> </aliases>
-            <definition>unit of power in decibel scale, referenced to 1 milliwatt; the power in bel-milliwatts is equal to 100 times the base 10 logarithm of the power in milliwatts (making decibel-milliwatt, the more common term, 10 times the base 10 log of the power in watts)</definition>
+            <definition>unit of power in decibel scale, referenced to 1 milliwatt; the power in bel-milliwatts is equal to 100 times the base 10 logarithm of the power in milliwatts (making decibel-milliwatt, the more common term, 10 times the base 10 log of the power in milliwatts)</definition>
         </unit>
 
     <!-- Heat -->


### PR DESCRIPTION
The detailed description incorrectly specified "relative to one watt" when it should read "relative to one milliwatt." Probably a copy-paste error from BW.