### PR TITLE
Fix for _MSC_VER check in udunits2.h

### DIFF
--- a/lib/udunits2.h
+++ b/lib/udunits2.h
@@ -11,7 +11,7 @@
 #include <stdarg.h>
 #include <stddef.h>
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && _MSC_VER<1910
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdarg.h>


### PR DESCRIPTION
The check on line 14 in udunits2.h applies a fix for windows build systems, which breaks more recent versions, as the functions being remapped now exist in the Windows SDK. A simple fix has been applied which only applies the remapping if _MSC_VER < 1910 (equivalent to Visual Studio 2017).

Tested with _MSC_VER == 1920 (Visual Studio 2019)