### PR TITLE
prog/udunits2.c: suppress -Wparentheses warning

### DIFF
--- a/prog/udunits2.c
+++ b/prog/udunits2.c
@@ -213,7 +213,7 @@ duplower(
     else {
         char*   cp = copy;
 
-        while (*cp++ = tolower(*string++))
+        while ((*cp++ = tolower(*string++)))
             ; /* empty */
     }
 


### PR DESCRIPTION
Recent compilers' `-Wparentheses` will warn if an assignment is used in a condition (in case the programmer meant to use `==`):

```
UDUNITS-2-2.2.27.14/prog/udunits2.c:216:22: warning: using the result of an assignment as a condition without parentheses [-Wparentheses]
        while (*cp++ = tolower(*string++))
               ~~~~~~^~~~~~~~~~~~~~~~~~~~
/opt/local/var/macports/build/_Users_runner_work_1_s_science_udunits2/udunits2/work/UDUNITS-2-2.2.27.14/prog/udunits2.c:216:22: note: place parentheses around the assignment to silence this warning
        while (*cp++ = tolower(*string++))
                     ^
               (                         )
/opt/local/var/macports/build/_Users_runner_work_1_s_science_udunits2/udunits2/work/UDUNITS-2-2.2.27.14/prog/udunits2.c:216:22: note: use '==' to turn this assignment into an equality comparison
        while (*cp++ = tolower(*string++))
                     ^
                     ==
1 warning generated.
```

Surrounding the assignment with additional parentheses indicates that the assignment is intentional, preventing the warning.