### PR TITLE
testUnits.c: Add return type to test_timeResolution

### DIFF
--- a/lib/testUnits.c
+++ b/lib/testUnits.c
@@ -2252,6 +2252,7 @@ test_xml(void)
     ut_free_system(xmlSystem);
 }
 
+
 static void
 test_mm2_day2_divide(void)
 {
@@ -2281,6 +2282,7 @@ test_mm2_day2_divide(void)
 }
 
 
+static void
 test_timeResolution(void)
 {
     ut_system*  xmlSystem;


### PR DESCRIPTION
With strict compiler settings:

```
third_party/udunits/lib/testUnits.c:2290:1: error: type specifier missing, defaults to 'int' [-Werror,-Wimplicit-int]
test_timeResolution(void)
^
third_party/udunits/lib/testUnits.c:2310:1: error: non-void function does not return a value [-Werror,-Wreturn-type]
}
^
``