### PR TITLE
Update DOI link (closes issue #106)

### DIFF
--- a/DOI
+++ b/DOI
@@ -1,1 +1,1 @@
-https://ezid.cdlib.org/id/doi:10.5065/D6KD1WN0
+https://doi.org/10.5065/D6KD1WN0


### PR DESCRIPTION
Update the file DOI to use the standard format `https://doi.org/.....`