### PR TITLE
Changed patterns to correctly capture UTF8 superscripts

### DIFF
--- a/lib/scanner.l
+++ b/lib/scanner.l
@@ -111,7 +111,7 @@ hour			[+-]?[0-1]?[0-9]|2[0-3]
 minute			[0-5]?[0-9]
 second			({minute}|60)(\.[0-9]*)?
 middot                  \xc2\xb7
-utf8_exp_digit	        \xc2(\xb9|\xb2|\xb3)|\xe2\x81(\xb0|[\xb4-\xb9])
+utf8_exp_digit	        \xc2\xb9|\xc2\xb2|\xc2\xb3|\xe2\x81\xb0|\xe2\x81\xb4|\xe2\x81\xb5|\xe2\x81\xb6|\xe2\x81\xb7|\xe2\x81\xb8|\xe2\x81\xb9
 utf8_exp_sign		\xe2\x81\xba|\xe2\x81\xbb
 utf8_exponent		{utf8_exp_sign}?{utf8_exp_digit}+
 nbsp                    \xc2\xa0
@@ -123,9 +123,9 @@ blk2                    \xc3([\x98-\xB6])
 blk3                    \xc3([\xB8-\xBF])
 latin1		        {nbsp}|{shy}|{degree}|{mu}|{blk1}|{blk2}|{blk3}
 utf8_cont               [\x80-\xbf]
-utf8_2bytes             [\xc8-\xdf]{utf8_cont}
-utf8_3bytes             [\xe0-\xef]{utf8_cont}{utf8_cont}
-letter  		[_a-zA-Z]|{latin1}|{utf8_2bytes}|{utf8_3bytes}
+utf8_2bytes_no_super    \xc2[\x80-\xb0\xb4-\xb5\xba-\xff]|[\xc8-\xdf]{utf8_cont}
+utf8_3bytes_no_super    [\xe0-\xe1]{utf8_cont}{utf8_cont}|\xe2[\x80\x82-\xff]{utf8_cont}|\xe2\x81[\x80-\xaf\xbc-\xff]|[\xe3-\xef]{utf8_cont}{utf8_cont}
+letter  		[_a-zA-Z]|{latin1}|{utf8_2bytes_no_super}|{utf8_3bytes_no_super}
 alphanum		{letter}|[0-9]
 id			%|'|\"|{letter}({alphanum}*{letter})?
 broken_date		{year}-{month}(-{day})?

--- a/lib/scanner.l
+++ b/lib/scanner.l
@@ -123,8 +123,8 @@ blk2                    \xc3([\x98-\xB6])
 blk3                    \xc3([\xB8-\xBF])
 latin1		        {nbsp}|{shy}|{degree}|{mu}|{blk1}|{blk2}|{blk3}
 utf8_cont               [\x80-\xbf]
-utf8_2bytes_no_super    \xc2[\x80-\xb0\xb4-\xb5\xba-\xff]|[\xc8-\xdf]{utf8_cont}
-utf8_3bytes_no_super    [\xe0-\xe1]{utf8_cont}{utf8_cont}|\xe2[\x80\x82-\xff]{utf8_cont}|\xe2\x81[\x80-\xaf\xbc-\xff]|[\xe3-\xef]{utf8_cont}{utf8_cont}
+utf8_2bytes_no_super    \xc2[\x80-\xb0\xb4-\xb5\xba-\xbf]|[\xc8-\xdf]{utf8_cont}
+utf8_3bytes_no_super    [\xe0-\xe1]{utf8_cont}{utf8_cont}|\xe2[\x80\x82-\xbf]{utf8_cont}|\xe2\x81[\x80-\xaf\xbc-\xbf]|[\xe3-\xef]{utf8_cont}{utf8_cont}
 letter  		[_a-zA-Z]|{latin1}|{utf8_2bytes_no_super}|{utf8_3bytes_no_super}
 alphanum		{letter}|[0-9]
 id			%|'|\"|{letter}({alphanum}*{letter})?

--- a/lib/testUnits.c
+++ b/lib/testUnits.c
@@ -2166,6 +2166,90 @@ test_xml(void)
 #endif
     ut_free(unit1);
 
+    /*
+     * UTF-8 superscript exponent parsing (issue #128).
+     * Verify that superscript characters are tokenized as exponents,
+     * not swallowed into unit identifiers by the {letter}/{id} rules.
+     */
+
+    /* m² == m2 : 2-byte superscript digit */
+    unit1 = ut_parse(xmlSystem, "m2", UT_ASCII);
+    CU_ASSERT_PTR_NOT_NULL(unit1);
+    unit2 = ut_parse(xmlSystem, "m\xc2\xb2", UT_UTF8);  /* m² */
+    CU_ASSERT_PTR_NOT_NULL(unit2);
+    if (unit1 && unit2)
+        CU_ASSERT_EQUAL(ut_compare(unit1, unit2), 0);
+    ut_free(unit2);
+    ut_free(unit1);
+
+    /* m·s⁻² == m/s2 : middle dot, 3-byte superscript minus, 2-byte superscript digit */
+    unit1 = ut_parse(xmlSystem, "m/s2", UT_ASCII);
+    CU_ASSERT_PTR_NOT_NULL(unit1);
+    unit2 = ut_parse(xmlSystem,
+        "m\xc2\xb7s\xe2\x81\xbb\xc2\xb2", UT_UTF8);  /* m·s⁻² */
+    CU_ASSERT_PTR_NOT_NULL(unit2);
+    if (unit1 && unit2)
+        CU_ASSERT_EQUAL(ut_compare(unit1, unit2), 0);
+    ut_free(unit2);
+    ut_free(unit1);
+
+    /* kg·m⁻³ == kg/m3 : 3-byte superscript minus, 2-byte superscript digit */
+    unit1 = ut_parse(xmlSystem, "kg/m3", UT_ASCII);
+    CU_ASSERT_PTR_NOT_NULL(unit1);
+    unit2 = ut_parse(xmlSystem,
+        "kg\xc2\xb7m\xe2\x81\xbb\xc2\xb3", UT_UTF8);  /* kg·m⁻³ */
+    CU_ASSERT_PTR_NOT_NULL(unit2);
+    if (unit1 && unit2)
+        CU_ASSERT_EQUAL(ut_compare(unit1, unit2), 0);
+    ut_free(unit2);
+    ut_free(unit1);
+
+    /* kg·m²·s⁻³ == W (watt) : compound with mixed superscripts */
+    unit1 = ut_parse(xmlSystem, "W", UT_ASCII);
+    CU_ASSERT_PTR_NOT_NULL(unit1);
+    unit2 = ut_parse(xmlSystem,
+        "kg\xc2\xb7m\xc2\xb2\xc2\xb7s\xe2\x81\xbb\xc2\xb3",
+        UT_UTF8);  /* kg·m²·s⁻³ */
+    CU_ASSERT_PTR_NOT_NULL(unit2);
+    if (unit1 && unit2)
+        CU_ASSERT_EQUAL(ut_compare(unit1, unit2), 0);
+    ut_free(unit2);
+    ut_free(unit1);
+
+    /* m⁴ == m4 : 3-byte superscript digit (⁴ = \xe2\x81\xb4) */
+    unit1 = ut_parse(xmlSystem, "m4", UT_ASCII);
+    CU_ASSERT_PTR_NOT_NULL(unit1);
+    unit2 = ut_parse(xmlSystem, "m\xe2\x81\xb4", UT_UTF8);  /* m⁴ */
+    CU_ASSERT_PTR_NOT_NULL(unit2);
+    if (unit1 && unit2)
+        CU_ASSERT_EQUAL(ut_compare(unit1, unit2), 0);
+    ut_free(unit2);
+    ut_free(unit1);
+
+    /* Round-trip: format a unit as UTF-8, then parse the result back */
+    {
+        char fmtBuf[128];
+        int nfmt;
+        ut_unit* formatted_unit;
+        ut_unit* reparsed_unit;
+
+        formatted_unit = ut_parse(xmlSystem, "kg/m3", UT_ASCII);
+        CU_ASSERT_PTR_NOT_NULL_FATAL(formatted_unit);
+
+        nfmt = ut_format(formatted_unit, fmtBuf, sizeof(fmtBuf)-1,
+            UT_UTF8 | UT_DEFINITION);
+        CU_ASSERT_TRUE_FATAL(nfmt > 0);
+        fmtBuf[nfmt] = 0;
+
+        reparsed_unit = ut_parse(xmlSystem, fmtBuf, UT_UTF8);
+        CU_ASSERT_PTR_NOT_NULL(reparsed_unit);
+        if (reparsed_unit)
+            CU_ASSERT_EQUAL(ut_compare(formatted_unit, reparsed_unit), 0);
+
+        ut_free(reparsed_unit);
+        ut_free(formatted_unit);
+    }
+
     ut_free_system(xmlSystem);
 
     ut_set_error_message_handler(ut_ignore);


### PR DESCRIPTION
Closes issue #128.

1. Explicit UTF-8 superscript number, not range (line 114)

2. Update the **letter** pattern to exclude superscript characters, UTF-8 patterns excluding superscripts (line 126-128)
* The new `utf8_2bytes_no_super` **letter** pattern excludes: 
   * \xc2\xb1 (±, plus-minus, not relevant but close) 
   * \xc2\xb2 (² superscript 2) 
   * \xc2\xb3 (³ superscript 3) 
   * \xc2\xb3 (¶ pilcrow) 
   * \xc2\xb7 (· middle dot) 
   * \xc2\xb7 (¸ cedilla) 
   * \xc2\xb9 (¹ superscript 1) 
* The new `utf8_3bytes_no_super` **letter** pattern excludes: 
   * \xe2\x81\xb0 through \xe2\x81\xb9 (superscript digits ⁰, ⁴⁻⁹) 
   * \xe2\x81\xba and \xe2\x81\xbb (superscript + and -) 

This ensures that UTF-8 superscript characters are not captured as letters by the `{id}` rule and can instead be properly matched by the `{utf8_exponent}` rule.