### PR TITLE
Division/ratio:  in regex require space around "PER", optional for "/"

### DIFF
--- a/lib/scanner.l
+++ b/lib/scanner.l
@@ -154,7 +154,7 @@ per                     [Pp][Ee][Rr]
     return SHIFT;
 }
 
-<INITIAL,ID_SEEN>{space}*({per}|"/"){space}* {
+<INITIAL,ID_SEEN>({space}+{per}{space}+|{space}*"/"{space}*) {
     BEGIN INITIAL;
     return DIVIDE;
 }


### PR DESCRIPTION
Closes issue #129.

See github comment https://github.com/Unidata/UDUNITS-2/issues/129#issuecomment-3161466542