### PR TITLE
Disallow NaN and Inf in unit strings

### DIFF
--- a/lib/scanner.l
+++ b/lib/scanner.l
@@ -140,7 +140,9 @@ from                    [Ff][Rr][Oo][Mm]
 since                   [Ss][Ii][Nn][Cc][Ee]
 ref                     [Rr][Ee][Ff]
 per                     [Pp][Ee][Rr]
-
+nanspell     ([nN][aA][nN](\([^()]*\))?)
+infspell     ([iI][nN][fF]([iI][nN][iI][tT][yY])?)
+idchar       [A-Za-z0-9_]
 %Start		ID_SEEN SHIFT_SEEN DATE_SEEN CLOCK_SEEN
 
 %%
@@ -148,6 +150,12 @@ per                     [Pp][Ee][Rr]
 	BEGIN INITIAL;
 	_restartScanner = 0;
     }
+
+<INITIAL,SHIFT_SEEN>{sign}?{nanspell}{idchar} { yyless(0);}
+<INITIAL,SHIFT_SEEN>{sign}?{infspell}{idchar} { yyless(0);}
+
+<INITIAL,SHIFT_SEEN>{sign}?{nanspell} { yyerror("NaN is not allowed in unit expressions."); return 0; }
+<INITIAL,SHIFT_SEEN>{sign}?{infspell} { yyerror("Infinity is not allowed in unit expressions."); return 0; }
 
 <INITIAL,ID_SEEN>{space}*(@|{after}|{from}|{ref}|{since}){space}* {
     BEGIN SHIFT_SEEN;

--- a/lib/scanner.l
+++ b/lib/scanner.l
@@ -154,8 +154,8 @@ idchar       [A-Za-z0-9_]
 <INITIAL,SHIFT_SEEN>{sign}?{nanspell}{idchar} { yyless(0);}
 <INITIAL,SHIFT_SEEN>{sign}?{infspell}{idchar} { yyless(0);}
 
-<INITIAL,SHIFT_SEEN>{sign}?{nanspell} { yyerror("NaN is not allowed in unit expressions."); return 0; }
-<INITIAL,SHIFT_SEEN>{sign}?{infspell} { yyerror("Infinity is not allowed in unit expressions."); return 0; }
+<INITIAL,SHIFT_SEEN>{sign}?{nanspell} { ut_handle_error_message("NaN is not allowed in unit expressions"); return ERR; }
+<INITIAL,SHIFT_SEEN>{sign}?{infspell} { ut_handle_error_message("Infinity is not allowed in unit expressions"); return ERR; }
 
 <INITIAL,ID_SEEN>{space}*(@|{after}|{from}|{ref}|{since}){space}* {
     BEGIN SHIFT_SEEN;

--- a/lib/testUnits.c
+++ b/lib/testUnits.c
@@ -2005,6 +2005,43 @@ test_parsing(void)
     unit = ut_parse(unitSystem, spec, UT_LATIN1);
     CU_ASSERT_PTR_NULL(unit);
     CU_ASSERT_EQUAL(ut_get_status(), UT_SYNTAX);
+
+    /*
+     * NaN and Inf must be rejected in unit strings (issue #132).
+     */
+
+    /* Standalone NaN/Inf — must fail */
+    unit = ut_parse(unitSystem, "nan", UT_ASCII);
+    CU_ASSERT_PTR_NULL(unit);
+
+    unit = ut_parse(unitSystem, "NaN", UT_ASCII);
+    CU_ASSERT_PTR_NULL(unit);
+
+    unit = ut_parse(unitSystem, "NAN", UT_ASCII);
+    CU_ASSERT_PTR_NULL(unit);
+
+    unit = ut_parse(unitSystem, "inf", UT_ASCII);
+    CU_ASSERT_PTR_NULL(unit);
+
+    unit = ut_parse(unitSystem, "INF", UT_ASCII);
+    CU_ASSERT_PTR_NULL(unit);
+
+    unit = ut_parse(unitSystem, "infinity", UT_ASCII);
+    CU_ASSERT_PTR_NULL(unit);
+
+    unit = ut_parse(unitSystem, "Infinity", UT_ASCII);
+    CU_ASSERT_PTR_NULL(unit);
+
+    /* NaN/Inf with sign — must fail */
+    unit = ut_parse(unitSystem, "+nan", UT_ASCII);
+    CU_ASSERT_PTR_NULL(unit);
+
+    unit = ut_parse(unitSystem, "-inf", UT_ASCII);
+    CU_ASSERT_PTR_NULL(unit);
+
+    /* NaN with payload — must fail */
+    unit = ut_parse(unitSystem, "NaN(0)", UT_ASCII);
+    CU_ASSERT_PTR_NULL(unit);
 }
 
 
@@ -2249,6 +2286,28 @@ test_xml(void)
         ut_free(reparsed_unit);
         ut_free(formatted_unit);
     }
+     * Units starting with "nan" or "inf" must still parse when followed
+     * by identifier characters (issue #132).  These require the full XML
+     * database for prefix resolution.
+     */
+    unit1 = ut_parse(xmlSystem, "nanoPa", UT_ASCII);
+    CU_ASSERT_PTR_NOT_NULL(unit1);
+    ut_free(unit1);
+
+    unit1 = ut_parse(xmlSystem, "nanosecond", UT_ASCII);
+    CU_ASSERT_PTR_NOT_NULL(unit1);
+    ut_free(unit1);
+
+    unit1 = ut_parse(xmlSystem, "nanometer", UT_ASCII);
+    CU_ASSERT_PTR_NOT_NULL(unit1);
+    ut_free(unit1);
+
+    /* NaN/Inf as leading amount with a real unit — must fail even with XML system */
+    unit1 = ut_parse(xmlSystem, "nan m", UT_ASCII);
+    CU_ASSERT_PTR_NULL(unit1);
+
+    unit1 = ut_parse(xmlSystem, "inf kg", UT_ASCII);
+    CU_ASSERT_PTR_NULL(unit1);
 
     ut_free_system(xmlSystem);
 

--- a/lib/testUnits.c
+++ b/lib/testUnits.c
@@ -2286,6 +2286,7 @@ test_xml(void)
         ut_free(reparsed_unit);
         ut_free(formatted_unit);
     }
+    /*
      * Units starting with "nan" or "inf" must still parse when followed
      * by identifier characters (issue #132).  These require the full XML
      * database for prefix resolution.

--- a/prog/udunits2.c
+++ b/prog/udunits2.c
@@ -424,15 +424,13 @@ decodeInput(
 
     ut_free(_haveUnit);
 
-    int nbytes = 0;
     double amt;
-    const char *p = input;
     char *endp = NULL;
 
     errno = 0;
-    amt = strtod(p, &endp);
+    amt = strtod(input, &endp);
 
-    if (endp != p) {
+    if (endp != input) {
         /* We did consume something that looks like a number? */
         int next = (unsigned char)*endp;
 
@@ -453,7 +451,7 @@ decodeInput(
             /* Finite amount is OK: Accept and advance to the remainder. */
             _haveUnitAmount = amt;
             input = endp;
-            /* Optional: skip a single ASCII space if present (traditional behavior). */
+            /* Optional: skip any leading whitespace. */
             while (*input && isspace((unsigned char)*input)) {
                 ++input;
             }


### PR DESCRIPTION
Closes issue #132.

* New lexer rules to throw an error if a NaN or Inf[inity] (case insensitive) appears in the string.
* Updated `decodeInput` function in udunits2.c. Without this, an initial NaN or Inf will be captured as a numeric before handing over to the lexer. 