### PR TITLE
Updated footcandle exponent -- closes issue #142

### DIFF
--- a/lib/udunits2-common.xml
+++ b/lib/udunits2-common.xml
@@ -1850,7 +1850,7 @@ elements appear only within <aliases>.
 
     <!-- Illumination -->
         <unit>
-            <def>1.076391e-1 lx</def>
+            <def>1.076391e1 lx</def>
             <aliases>
                 <name> <singular>footcandle</singular> </name>
             </aliases>


### PR DESCRIPTION
Test/verification using command line tool:
```bash
# Check default XML database
./UDUNITS-2/lib$ udunits2 -h
Usage:
   ... ... ... ...
    <XML_file>  XML database file. Default is "/usr/share/xml/udunits/udunits2.xml".

# Use default XML database
./UDUNITS-2/lib$ udunits2 -H "footcandle" -W ""
    0.1076391 m⁻²·cd·rad²    # wrong

# Use updated XML database
./CODE/UDUNITS-2/lib$ udunits2 -H "footcandle" -W "" udunits2.xml
    10.76391 m⁻²·cd·rad²   # correct
```