### PR TITLE
Technical update:  git ignore build directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,7 @@ test-driver
 build-aux
 udunits2.t2p
 .settings
-build
+build*/
 html
 stamp-vti
 version.texi


### PR DESCRIPTION
Extend .gitignore to not only skip subdirectory `build/`, but also  `build-asan/` (and any other `build*/` directory) to better assist local test builds.