### PR TITLE
Improve buffer handling in the CLI and XML parser

### DIFF
--- a/lib/xml.c
+++ b/lib/xml.c
@@ -110,6 +110,14 @@ static ut_system*	unitSystem = NULL;
 static char*            text = NULL;
 static size_t           nbytes = 0; /// Number of characters excluding NUL
 
+/*
+ * Upper bound on the text accumulated for a single XML element. Element text
+ * becomes unit names, symbols, and definitions, all of which are far shorter
+ * than this and are separately bounded to NAME_SIZE-1 by their consumers. The
+ * cap exists only to bound memory when parsing an untrusted database.
+ */
+#define MAX_ELEMENT_TEXT (4*1024)
+
 
 /*
  * Returns the plural form of a name.
@@ -944,7 +952,16 @@ accumulateText(
     const char*		string,		/* input text in UTF-8 */
     int			len)
 {
-    char*	tmp = realloc(text, nbytes + len + 1);
+    char*	tmp;
+
+    if (len < 0 || nbytes + (size_t)len + 1 > MAX_ELEMENT_TEXT) {
+	ut_set_status(UT_SYNTAX);
+	ut_handle_error_message("Element text is too long");
+	XML_StopParser(currFile->parser, 0);
+	return;
+    }
+
+    tmp = realloc(text, nbytes + len + 1);
 
     if (tmp == NULL) {
         ut_set_status(UT_OS);

--- a/lib/xml.c
+++ b/lib/xml.c
@@ -351,6 +351,8 @@ utf8_to_latin1(
             return 0;
 
         if (!IS_ASCII(*in)) {
+            if (in[1] == 0)
+                return 0;       /* truncated multibyte sequence */
             numSpecial++;
             in++;
         }

--- a/lib/xml.c
+++ b/lib/xml.c
@@ -2166,8 +2166,12 @@ default_udunits2_xml_path()
             }
             else {
                 strncpy(buf, info.dli_fname, sizeof(buf))[sizeof(buf)-1] = 0;
-                memmove(buf, dirname(buf), sizeof(buf)); // "lib"
-                memmove(buf, dirname(buf), sizeof(buf)); // "lib/.."
+                {
+                    char* dir = dirname(buf);   // strip filename
+                    memmove(buf, dir, strlen(dir) + 1);
+                    dir = dirname(buf);         // strip "lib"
+                    memmove(buf, dir, strlen(dir) + 1);
+                }
                 prefix = buf;
             }
 #       elif defined(_WIN32)

--- a/prog/udunits2.c
+++ b/prog/udunits2.c
@@ -40,6 +40,12 @@
 #   define _POSIX_MAX_INPUT 255
 #endif
 
+/* Longest accepted unit specification, in bytes, excluding the NUL. */
+#define MAX_SPEC_LEN    _POSIX_MAX_INPUT
+
+/* Line buffer for interactive input: specification, newline, NUL. */
+#define SPEC_LINE_SIZE  (MAX_SPEC_LEN+2)
+
 static const char*      _cmdHave; /* command-line "have" unit specification */
 static const char*      _cmdWant; /* command-line "want" unit specification */
 static int		_reveal; /* reveal problems with unit database? */
@@ -49,9 +55,9 @@ static char             _progname[1024];
 static const char*	_xmlPath = NULL; /* use default path */
 static ut_system*	_unitSystem;
 static double           _haveUnitAmount; /* amount of "have" unit */
-static char		_haveUnitSpec[_POSIX_MAX_INPUT+1]; /* "have" unit minus
+static char		_haveUnitSpec[MAX_SPEC_LEN+1]; /* "have" unit minus
                                                               amount */
-static char		_wantSpec[_POSIX_MAX_INPUT+1]; /* complete "want" unit
+static char		_wantSpec[MAX_SPEC_LEN+1]; /* complete "want" unit
                                                           specification */
 static ut_unit*		_haveUnit; /* "have" unit minus amount */
 static ut_unit*		_wantUnit; /* complete "want" unit */
@@ -442,23 +448,57 @@ getSpec(
 {
     int		nbytes = -1;		/* failure */
 
-    if (fputs(prompt, stdout) == EOF) {
-	errMsg("Couldn't write prompt: %s", strerror(errno));
-    } else if (fgets(spec, (int)size, stdin) == NULL) {
-	putchar('\n');
+    for (;;) {
+	size_t	len;
 
-	if (feof(stdin)) {
-	    _exitStatus = EXIT_SUCCESS;
-	} else {
-	    errMsg("Couldn't read from standard input: %s", strerror(errno));
+	if (fputs(prompt, stdout) == EOF) {
+	    errMsg("Couldn't write prompt: %s", strerror(errno));
+	    break;
 	}
-    } else {
+
+	if (fgets(spec, (int)size, stdin) == NULL) {
+	    putchar('\n');
+
+	    if (feof(stdin)) {
+		_exitStatus = EXIT_SUCCESS;
+	    } else {
+		errMsg("Couldn't read from standard input: %s",
+		    strerror(errno));
+	    }
+	    break;
+	}
+
+	/*
+	 * A full buffer with no newline means the line was longer than the
+	 * buffer. Truncating it would silently change the specification, so
+	 * discard the remainder of the line and prompt again.
+	 */
+	len = strlen(spec);
+
+	if (len == size - 1 && spec[len-1] != '\n') {
+	    int	    c;
+
+	    errMsg("Unit specification is too long (limit is %u characters)",
+		(unsigned)(size - 2));
+
+	    while ((c = getc(stdin)) != EOF && c != '\n')
+		;
+
+	    if (c == EOF) {
+		_exitStatus = EXIT_SUCCESS;
+		break;
+	    }
+
+	    continue;
+	}
+
 	/*
 	 * Trim any whitespace from the specification.
 	 */
 	(void)ut_trim(spec, _encoding);
 
         nbytes = (int)strlen(spec);
+	break;
     }
 
     return nbytes;
@@ -510,6 +550,12 @@ decodeInput(
         _haveUnitAmount = 1;
     }
 
+    if (strlen(input) >= sizeof(_haveUnitSpec)) {
+	errMsg("Input unit specification is too long (limit is %u characters)",
+	    (unsigned)(sizeof(_haveUnitSpec) - 1));
+	return 0;
+    }
+
     (void)strncpy(_haveUnitSpec, input, sizeof(_haveUnitSpec));
     _haveUnitSpec[sizeof(_haveUnitSpec)-1] = 0;
     ut_error_message_handler prev_handler =
@@ -557,7 +603,7 @@ getInputValue(void)
     }
     else {
         for (;;) {
-            char    buf[sizeof(_haveUnitSpec)];
+            char    buf[SPEC_LINE_SIZE];
             int	nbytes = getSpec("You have: ", buf, sizeof(buf));
 
             if (nbytes < 0)
@@ -620,6 +666,13 @@ getOutputRequest(void)
             success = 1;
         }
         else {
+            if (strlen(_cmdWant) >= sizeof(_wantSpec)) {
+                errMsg("Output unit specification is too long "
+                    "(limit is %u characters)",
+                    (unsigned)(sizeof(_wantSpec) - 1));
+                return 0;
+            }
+
             (void)strncpy(_wantSpec, _cmdWant, sizeof(_wantSpec));
             _wantSpec[sizeof(_wantSpec)-1] = 0;
 
@@ -629,10 +682,15 @@ getOutputRequest(void)
     }
     else {
         for (;;) {
-            int	nbytes = getSpec("You want: ", _wantSpec, sizeof(_wantSpec));
+            char	buf[SPEC_LINE_SIZE];
+            int	nbytes = getSpec("You want: ", buf, sizeof(buf));
 
             if (nbytes < 0)
                 break;
+
+            /* getSpec() has already bounded the length. */
+            (void)strncpy(_wantSpec, buf, sizeof(_wantSpec));
+            _wantSpec[sizeof(_wantSpec)-1] = 0;
 
             success = decodeOutput(_wantSpec);
 

--- a/prog/udunits2.c
+++ b/prog/udunits2.c
@@ -18,6 +18,7 @@
 #endif
 
 #include <errno.h>
+#include <assert.h>
 #include <ctype.h>
 #ifndef _MSC_VER
 #include <libgen.h>
@@ -678,7 +679,8 @@ handleRequest(void)
 		    errMsg("Couldn't get unit converter");
 		}
 		else {
-                    char        haveExp[_POSIX_MAX_INPUT+1];
+                    /* Room for the specification plus "(x/(" and "))". */
+                    char        haveExp[sizeof(_haveUnitSpec)+8];
                     char        exp[_POSIX_MAX_INPUT+1];
                     char        whiteSpace[] = " \t\n\r\f\v\xa0";
 		    int	        needsParens =
@@ -694,12 +696,14 @@ handleRequest(void)
 			cv_convert_double(conv, _haveUnitAmount),
                         _wantSpec);
 
-                    (void)sprintf(haveExp,
+                    n = snprintf(haveExp, sizeof(haveExp),
                         strpbrk(_haveUnitSpec, whiteSpace) ||
                                 strpbrk(_haveUnitSpec, "/")
                             ? "(x/(%s))"
                             : "(x/%s)",
                         _haveUnitSpec);
+
+                    assert(n >= 0 && (size_t)n < sizeof(haveExp));
 
                     n = cv_get_expression(conv, exp, sizeof(exp), haveExp);
 


### PR DESCRIPTION
Five independent bounds fixes, one per commit. 

This PR depends on #167 being merged to make the two Windows CI checks green.  It will be rebased and force-pushed once #167 lands, then un-drafted.

**`prog/udunits2.c`**

- The reverse-conversion expression was built with an unbounded `sprintf()` into a buffer the same size as its input, so a near-maximal `-H` specification wrote past the end. On a `_FORTIFY_SOURCE` build this aborts; the reproducer is in the commit message. The buffer is now sized to hold the specification plus the format overhead, and filled with
  `snprintf()`.
- Both specification buffers were filled with `strncpy()` bounded by their own size, so over-length input was silently truncated and then parsed; the tool reported a successful conversion of a unit the user had not entered, with no diagnostic. Interactive input had the same defect in a different form: `fgets()` split an over-long line and consumed its tail as the next specification. Over-length specifications are now rejected on all three paths, which all accept 255 characters and report the same limit.

**`lib/xml.c`**

- `accumulateText()` grew without limit, so one huge element text node allocated until the process died. Now capped per element.
- `memmove(buf, dirname(buf), sizeof(buf))` over-reads when `dirname()` returns static storage. Now copies the actual length.
- `utf8_to_latin1()` stepped over the NUL on a string ending in a lead byte. Such strings are now rejected as unrepresentable.

Only the first has a demonstrated trigger. The three `xml.c` changes are latent: the last two take input the caller cannot influence, and the cap only matters for an untrusted database.

`ctest` passes 3/3 under ASan+UBSan with `-fno-sanitize-recover=all`, on this branch and on `main`. Each commit was built and tested independently. Ordinary conversions are unchanged. All array sizes added here are constant expressions, not VLAs, per the portability note in CMakeLists.txt.

No `CHANGE_LOG` entry pending the outcome of #158. Suggested wording for whenever that is settled:

> Corrected several unchecked buffer bounds. A pathological unit specification crashes `udunits2.c` and an over-long one is silently truncated before parsing; three further cases in `xml.c` are latent.

