### PR TITLE
fix(lib): limit the snprintf replacement to the MSVC versions needing it

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -56,7 +56,12 @@ SET(libudunits2_src converter.c
 
 if(MSVC)
 	SET(libudunits2_src ${libudunits2_src}
-	tsearch.c tsearch.h udunits_snprintf.c)
+	tsearch.c tsearch.h)
+
+	# Only needed before Visual Studio 2015; see lib/udunits2.h.
+	if(MSVC_VERSION LESS 1900)
+		SET(libudunits2_src ${libudunits2_src} udunits_snprintf.c)
+	endif()
 endif()
 
 add_library(libudunits2

--- a/lib/udunits2.h
+++ b/lib/udunits2.h
@@ -29,8 +29,16 @@
 #define stricmp _stricmp
 #define isatty _isatty
 
-//We must accommodate the lack of snprintf in versions of MSVC less than 1900.
-//udunits_snprintf is defined in udunits_snprintf.c, in lib/.
+/*
+ * MSVC gained a conforming snprintf() in Visual Studio 2015 (_MSC_VER 1900).
+ * Older versions need the replacement in udunits_snprintf.c.
+ *
+ * The version test matters beyond dead code: this macro is in a public
+ * header, so it rewrites snprintf() in every translation unit that includes
+ * udunits2.h, including those of library users.  udunits_snprintf() is not
+ * exported from the DLL, so each such call fails to link.
+ */
+#if _MSC_VER < 1900
 #define snprintf udunits_snprintf
 
 int udunits_snprintf(
@@ -44,6 +52,7 @@ char* str,
   size_t size,
   const char* format,
   va_list ap);
+#endif
 
 #endif
 


### PR DESCRIPTION
`lib/udunits2.h` redefines `snprintf` as `udunits_snprintf` under a bare `#ifdef _MSC_VER`, although the comments there and in `udunits_snprintf.c` both say the replacement is only for MSVC before Visual Studio 2015 (`_MSC_VER` 1900).

The macro is in a public header, so it rewrites `snprintf` in every translation unit that includes it — including those of library users. `udunits_snprintf` is not exported from the DLL, so those calls do not link. It stays latent only because nothing outside `lib/` currently calls `snprintf`: `prog/udunits2.c` uses `vsnprintf`, which is not rewritten.

Adds the version test the comments already describe, and builds `udunits_snprintf.c` only when it is needed. No change for MSVC 19.x or for non-MSVC compilers.

Prerequisite for #166, where the first `snprintf` call from `prog/` produces:
```
    udunits2.obj : error LNK2019: unresolved external symbol
        udunits_snprintf referenced in function handleRequest
```